### PR TITLE
Update artemis-java-test-sandbox to Version 1.5.3

### DIFF
--- a/artemis-java-template/pom.xml
+++ b/artemis-java-template/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>de.tum.in.ase</groupId>
             <artifactId>artemis-java-test-sandbox</artifactId>
-            <version>1.5.2</version>
+            <version>1.5.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Just a dependency update of `artemis-java-test-sandbox`. This introduces optional modifiers for the structural tests and modifiers for classes.

For details, see
 - https://github.com/ls1intum/artemis-java-test-sandbox/releases/tag/1.5.3
