### PR TITLE
Update artemis-java-test-sandbox to Version 1.7.0

### DIFF
--- a/artemis-java-template/pom.xml
+++ b/artemis-java-template/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>de.tum.in.ase</groupId>
             <artifactId>artemis-java-test-sandbox</artifactId>
-            <version>1.5.5</version>
+            <version>1.7.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -29,13 +29,13 @@
         <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
-            <version>5.7.2</version>
+            <version>5.8.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-testkit</artifactId>
-            <version>1.7.2</version>
+            <version>1.8.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Just a dependency update of `artemis-java-test-sandbox`. This fixes a few bugs and updates JUnit 5 and AssertJ.

For details, see
 - https://github.com/ls1intum/artemis-java-test-sandbox/releases/tag/1.6.0
 - https://github.com/ls1intum/artemis-java-test-sandbox/releases/tag/1.7.0

We also update the JUnit 5 version numbers in the `pom.xml` to match the new version Ares uses.