### PR TITLE
Enhancement: Add GitHub workflow to build and push images to DockerHub and GitHub Registry

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -61,7 +61,7 @@ jobs:
           TAG: ${{ steps.compute-tag.outputs.result }}
         run: |
           docker buildx build --push \
-          --tag ${{secrets.DOCKER_USERNAME}}/artemis-maven-template:$TAG \
+          --tag ls1tum/artemis-maven-template:$TAG \
           --platform linux/amd64,linux/arm64/v8 .
         if: ${{ steps.compute-tag.outputs.result != 'FALSE' }}
 

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -16,21 +16,7 @@ jobs:
     name: Build and Push the Docker Images
     runs-on: ubuntu-latest
     steps:
-      - name: Check if Release Version
-        uses: actions/github-script@v6
-        id: check-if-release
-        with:
-          result-encoding: string
-          script: |
-            if (context.eventName === "push") {
-              if (context.ref.startsWith("refs/tags/")) {
-                return "TRUE";
-              }
-            }
-            return "FALSE";
-
-      -
-        name: Compute Tag
+      - name: Compute Tag
         uses: actions/github-script@v6
         id: compute-tag
         with:
@@ -40,7 +26,7 @@ jobs:
               return "pr-" + context.issue.number;
             }
             if (context.eventName === "push") {
-              if (steps.check-if-release.result == 'TRUE') {
+              if (context.ref.startsWith("refs/tags/")) {
                 return context.ref.slice(10);
               }
               if (context.ref === "refs/heads/main") {
@@ -88,4 +74,7 @@ jobs:
             ls1tum/artemis-maven-template:${{ steps.compute-tag.outputs.result }}
             ghcr.io/ls1intum/artemis-maven-docker:${{ steps.compute-tag.outputs.result }}
           platforms: linux/amd64,linux/arm64/v8
-          push: ${{ steps.check-if-release.result == 'FALSE' }}
+          push: |
+            ${{ steps.compute-tag.outputs.result.startsWith("pr-") != true
+            && steps.compute-tag.outputs.result != "latest"
+            && steps.compute-tag.outputs.result != "FALSE" }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -16,7 +16,21 @@ jobs:
     name: Build and Push the Docker Images
     runs-on: ubuntu-latest
     steps:
-      - name: Compute Tag
+      - name: Check if Release Version
+        uses: actions/github-script@v6
+        id: check-if-release
+        with:
+          result-encoding: boolean
+          script: |
+            if (context.eventName === "push") {
+              if (context.ref.startsWith("refs/tags/")) {
+                return true;
+              }
+            }
+            return false;
+
+      -
+        name: Compute Tag
         uses: actions/github-script@v6
         id: compute-tag
         with:
@@ -26,7 +40,7 @@ jobs:
               return "pr-" + context.issue.number;
             }
             if (context.eventName === "push") {
-              if (context.ref.startsWith("refs/tags/")) {
+              if (steps.check-if-release.result) {
                 return context.ref.slice(10);
               }
               if (context.ref === "refs/heads/main") {
@@ -74,7 +88,4 @@ jobs:
             ls1tum/artemis-maven-template:${{ steps.compute-tag.outputs.result }}
             ghcr.io/ls1intum/artemis-maven-docker:${{ steps.compute-tag.outputs.result }}
           platforms: linux/amd64,linux/arm64/v8
-          push: |
-            ${{ !steps.compute-tag.outputs.result.startsWith("pr-")
-            && steps.compute-tag.outputs.result != "latest"
-            && steps.compute-tag.outputs.result != "FALSE" }}
+          push: ${{ steps.check-if-release.result }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -70,10 +70,10 @@ jobs:
         env:
           TAG: ${{ steps.compute-tag.outputs.result }}
         run: |
-          docker buildx build --push \
+          docker buildx build -t --push \
             --tag ls1tum/artemis-maven-template:$TAG \
             --platform linux/amd64,linux/arm64/v8 .
-          docker image ls -a
+          docker images
           docker tag ls1tum/artemis-maven-template:$TAG ghcr.io/ls1intum/artemis-maven-template:$TAG
           docker push ghcr.io/ls1intum/artemis-maven-template:$TAG
         if: ${{ steps.compute-tag.outputs.result != 'FALSE' }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -67,13 +67,11 @@ jobs:
 
       -
         name: Build Image and Push to GitHub Container Registry and DockerHub
-        env:
-          TAG: ${{ steps.compute-tag.outputs.result }}
         uses: docker/build-push-action@v2
         with:
           context: .
           tags: |
-            ls1tum/artemis-maven-docker:$TAG
-            ghcr.io/ls1intum/artemis-maven-docker:$TAG
+            ls1tum/artemis-maven-docker:${{ steps.compute-tag.outputs.result }}
+            ghcr.io/ls1intum/artemis-maven-docker:${{ steps.compute-tag.outputs.result }}
           platforms: linux/amd64,linux/arm64/v8
           push: ${{ steps.compute-tag.outputs.result != 'FALSE' }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -20,14 +20,14 @@ jobs:
         uses: actions/github-script@v6
         id: check-if-release
         with:
-          result-encoding: boolean
+          result-encoding: string
           script: |
             if (context.eventName === "push") {
               if (context.ref.startsWith("refs/tags/")) {
-                return true;
+                return "TRUE";
               }
             }
-            return false;
+            return "FALSE";
 
       -
         name: Compute Tag
@@ -40,7 +40,7 @@ jobs:
               return "pr-" + context.issue.number;
             }
             if (context.eventName === "push") {
-              if (steps.check-if-release.result) {
+              if (steps.check-if-release.result == "TRUE") {
                 return context.ref.slice(10);
               }
               if (context.ref === "refs/heads/main") {
@@ -88,4 +88,4 @@ jobs:
             ls1tum/artemis-maven-template:${{ steps.compute-tag.outputs.result }}
             ghcr.io/ls1intum/artemis-maven-docker:${{ steps.compute-tag.outputs.result }}
           platforms: linux/amd64,linux/arm64/v8
-          push: ${{ steps.check-if-release.result }}
+          push: ${{ steps.check-if-release.result == "FALSE" }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,0 +1,79 @@
+name: Build and Push
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  buildx:
+    name: Build and Push the Docker Images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compute Tag
+          uses: actions/github-script@v6
+          id: compute-tag
+          with:
+            result-encoding: string
+            script: |
+              if (context.eventName === "pull_request") {
+                return "pr-" + context.issue.number;
+              }
+              if (context.eventName === "push") {
+                if (context.ref.startsWith("refs/tags/")) {
+                  return context.ref.slice(10);
+                }
+                if (context.ref === "refs/heads/develop") {
+                  return "latest";
+                }
+              }
+              return "FALSE";
+
+      - uses: actions/checkout@v2
+        name: Docker Login
+        id: docker-login
+        env:
+          DOCKER_USER: ${{secrets.DOCKER_USERNAME}}
+          DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
+        run: |
+          docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
+      -
+        name: Install Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+        with:
+          version: latest
+
+      -
+        name: Build the Image
+        env:
+          TAG: ${{ steps.compute-tag.outputs.result }}
+        run: |
+          docker buildx build --push \
+          --tag ${{secrets.DOCKER_USERNAME}}/artemis-maven-template:$TAG \
+          --platform linux/amd64,linux/arm64/v8 .
+
+      # Push to GitHub Container Registry
+      -
+        name: Login to GitHub Container Registry
+          uses: docker/login-action@v1
+          with:
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+          if: ${{ steps.compute-tag.outputs.result != 'FALSE' }}
+
+      -
+        name: Push to GitHub Container Registry
+          env:
+            TAG: ${{ steps.compute-tag.outputs.result }}
+          run: |
+            docker tag artemis-maven-template ghcr.io/ls1intum/artemis-maven-template:$TAG
+            docker push ghcr.io/ls1intum/artemis-maven-template:$TAG
+          if: ${{ steps.compute-tag.outputs.result != 'FALSE' }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,9 +1,15 @@
 name: Build and Push
 
 on:
+  pull_request:
   push:
     branches:
       - main
+      - release/*
+    tags: '[0-9]+.[0-9]+.[0-9]+'
+  release:
+    types:
+      - created
 
 jobs:
   buildx:
@@ -23,7 +29,7 @@ jobs:
               if (context.ref.startsWith("refs/tags/")) {
                 return context.ref.slice(10);
               }
-              if (context.ref === "refs/heads/develop") {
+              if (context.ref === "refs/heads/main") {
                 return "latest";
               }
             }
@@ -34,11 +40,8 @@ jobs:
       -
         name: Docker Login
         id: docker-login
-        env:
-          DOCKER_USER: ${{secrets.DOCKER_USERNAME}}
-          DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
         run: |
-          docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
+          docker login -u ${{secrets.DOCKER_USERNAME}} -p ${{secrets.DOCKER_PASSWORD}}
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -60,6 +63,7 @@ jobs:
           docker buildx build --push \
           --tag ${{secrets.DOCKER_USERNAME}}/artemis-maven-template:$TAG \
           --platform linux/amd64,linux/arm64/v8 .
+        if: ${{ steps.compute-tag.outputs.result != 'FALSE' }}
 
       # Push to GitHub Container Registry
       -

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -80,6 +80,6 @@ jobs:
         env:
           TAG: ${{ steps.compute-tag.outputs.result }}
         run: |
-          docker tag ls1tum/artemis-maven-template ghcr.io/ls1intum/artemis-maven-template:$TAG
+          docker tag ls1tum/artemis-maven-template:$TAG ghcr.io/ls1intum/artemis-maven-template:$TAG
           docker push ghcr.io/ls1intum/artemis-maven-template:$TAG
         if: ${{ steps.compute-tag.outputs.result != 'FALSE' }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -68,13 +68,11 @@ jobs:
       -
         name: Build Image and Push to GitHub Container Registry and DockerHub
         uses: docker/build-push-action@v2
+        if: ${{ steps.compute-tag.outputs.result != 'FALSE' }}
         with:
           context: .
           tags: |
             ls1tum/artemis-maven-template:${{ steps.compute-tag.outputs.result }}
             ghcr.io/ls1intum/artemis-maven-docker:${{ steps.compute-tag.outputs.result }}
           platforms: linux/amd64,linux/arm64/v8
-          push: |
-            ${{ !startsWith(steps.compute-tag.outputs.result, 'pr-')
-            && steps.compute-tag.outputs.result != 'latest'
-            && steps.compute-tag.outputs.result != 'FALSE' }}
+          push: ${{ !startsWith(steps.compute-tag.outputs.result, 'pr-') }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -70,7 +70,7 @@ jobs:
         env:
           TAG: ${{ steps.compute-tag.outputs.result }}
         run: |
-          docker buildx build -t --push \
+          docker buildx build -t ls1tum/artemis-maven-template:$TAG --load --push \
             --tag ls1tum/artemis-maven-template:$TAG \
             --platform linux/amd64,linux/arm64/v8 .
           docker images

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -80,6 +80,6 @@ jobs:
         env:
           TAG: ${{ steps.compute-tag.outputs.result }}
         run: |
-          docker tag artemis-maven-template ghcr.io/ls1intum/artemis-maven-template:$TAG
+          docker tag ls1tum/artemis-maven-template ghcr.io/ls1intum/artemis-maven-template:$TAG
           docker push ghcr.io/ls1intum/artemis-maven-template:$TAG
         if: ${{ steps.compute-tag.outputs.result != 'FALSE' }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -42,6 +42,16 @@ jobs:
         id: docker-login
         run: |
           docker login -u ${{secrets.DOCKER_USERNAME}} -p ${{secrets.DOCKER_PASSWORD}}
+
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ steps.compute-tag.outputs.result != 'FALSE' }}
+
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -56,30 +66,13 @@ jobs:
           version: latest
 
       -
-        name: Build the Image
+        name: Build Image and Push to GitHub Container Registry and DockerHub
         env:
           TAG: ${{ steps.compute-tag.outputs.result }}
         run: |
           docker buildx build --push \
-          --tag ls1tum/artemis-maven-template:$TAG \
-          --platform linux/amd64,linux/arm64/v8 .
-        if: ${{ steps.compute-tag.outputs.result != 'FALSE' }}
-
-      # Push to GitHub Container Registry
-      -
-        name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ steps.compute-tag.outputs.result != 'FALSE' }}
-
-      -
-        name: Push to GitHub Container Registry
-        env:
-          TAG: ${{ steps.compute-tag.outputs.result }}
-        run: |
+            --tag ls1tum/artemis-maven-template:$TAG \
+            --platform linux/amd64,linux/arm64/v8 .
           docker image ls -a
           docker tag ls1tum/artemis-maven-template:$TAG ghcr.io/ls1intum/artemis-maven-template:$TAG
           docker push ghcr.io/ls1intum/artemis-maven-template:$TAG

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -40,7 +40,7 @@ jobs:
               return "pr-" + context.issue.number;
             }
             if (context.eventName === "push") {
-              if (steps.check-if-release.result == "TRUE") {
+              if (steps.check-if-release.result == 'TRUE') {
                 return context.ref.slice(10);
               }
               if (context.ref === "refs/heads/main") {
@@ -88,4 +88,4 @@ jobs:
             ls1tum/artemis-maven-template:${{ steps.compute-tag.outputs.result }}
             ghcr.io/ls1intum/artemis-maven-docker:${{ steps.compute-tag.outputs.result }}
           platforms: linux/amd64,linux/arm64/v8
-          push: ${{ steps.check-if-release.result == "FALSE" }}
+          push: ${{ steps.check-if-release.result == 'FALSE' }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -75,6 +75,6 @@ jobs:
             ghcr.io/ls1intum/artemis-maven-docker:${{ steps.compute-tag.outputs.result }}
           platforms: linux/amd64,linux/arm64/v8
           push: |
-            ${{ steps.compute-tag.outputs.result.startsWith('pr-') != true
+            ${{ !startsWith(steps.compute-tag.outputs.result, 'pr-')
             && steps.compute-tag.outputs.result != 'latest'
             && steps.compute-tag.outputs.result != 'FALSE' }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -44,15 +44,6 @@ jobs:
           docker login -u ${{secrets.DOCKER_USERNAME}} -p ${{secrets.DOCKER_PASSWORD}}
 
       -
-        name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ steps.compute-tag.outputs.result != 'FALSE' }}
-
-      -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:
@@ -72,6 +63,5 @@ jobs:
           context: .
           tags: |
             ls1tum/artemis-maven-docker:${{ steps.compute-tag.outputs.result }}
-            ghcr.io/ls1intum/artemis-maven-docker:${{ steps.compute-tag.outputs.result }}
           platforms: linux/amd64,linux/arm64/v8
           push: ${{ steps.compute-tag.outputs.result != 'FALSE' }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -70,7 +70,7 @@ jobs:
         env:
           TAG: ${{ steps.compute-tag.outputs.result }}
         run: |
-          docker buildx build -t ls1tum/artemis-maven-template:$TAG --load --push \
+          docker buildx build -t ls1tum/artemis-maven-template:$TAG --push \
             --tag ls1tum/artemis-maven-template:$TAG \
             --platform linux/amd64,linux/arm64/v8 .
           docker images

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -80,6 +80,7 @@ jobs:
         env:
           TAG: ${{ steps.compute-tag.outputs.result }}
         run: |
+          docker image ls -a
           docker tag ls1tum/artemis-maven-template:$TAG ghcr.io/ls1intum/artemis-maven-template:$TAG
           docker push ghcr.io/ls1intum/artemis-maven-template:$TAG
         if: ${{ steps.compute-tag.outputs.result != 'FALSE' }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -62,18 +62,18 @@ jobs:
       # Push to GitHub Container Registry
       -
         name: Login to GitHub Container Registry
-          uses: docker/login-action@v1
-          with:
-            registry: ghcr.io
-            username: ${{ github.actor }}
-            password: ${{ secrets.GITHUB_TOKEN }}
-          if: ${{ steps.compute-tag.outputs.result != 'FALSE' }}
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ steps.compute-tag.outputs.result != 'FALSE' }}
 
       -
         name: Push to GitHub Container Registry
-          env:
-            TAG: ${{ steps.compute-tag.outputs.result }}
-          run: |
-            docker tag artemis-maven-template ghcr.io/ls1intum/artemis-maven-template:$TAG
-            docker push ghcr.io/ls1intum/artemis-maven-template:$TAG
-          if: ${{ steps.compute-tag.outputs.result != 'FALSE' }}
+        env:
+          TAG: ${{ steps.compute-tag.outputs.result }}
+        run: |
+          docker tag artemis-maven-template ghcr.io/ls1intum/artemis-maven-template:$TAG
+          docker push ghcr.io/ls1intum/artemis-maven-template:$TAG
+        if: ${{ steps.compute-tag.outputs.result != 'FALSE' }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -44,6 +44,15 @@ jobs:
           docker login -u ${{secrets.DOCKER_USERNAME}} -p ${{secrets.DOCKER_PASSWORD}}
 
       -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ steps.compute-tag.outputs.result != 'FALSE' }}
+
+      -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:
@@ -62,6 +71,7 @@ jobs:
         with:
           context: .
           tags: |
-            ls1tum/artemis-maven-docker:${{ steps.compute-tag.outputs.result }}
+            ls1tum/artemis-maven-template:${{ steps.compute-tag.outputs.result }}
+            ghcr.io/ls1intum/artemis-maven-docker:${{ steps.compute-tag.outputs.result }}
           platforms: linux/amd64,linux/arm64/v8
           push: ${{ steps.compute-tag.outputs.result != 'FALSE' }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -74,4 +74,4 @@ jobs:
             ls1tum/artemis-maven-template:${{ steps.compute-tag.outputs.result }}
             ghcr.io/ls1intum/artemis-maven-docker:${{ steps.compute-tag.outputs.result }}
           platforms: linux/amd64,linux/arm64/v8
-          push: ${{ steps.compute-tag.outputs.result != 'FALSE' }}
+          push: ${{ context.ref.startsWith("refs/tags/") }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -11,23 +11,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Compute Tag
-          uses: actions/github-script@v6
-          id: compute-tag
-          with:
-            result-encoding: string
-            script: |
-              if (context.eventName === "pull_request") {
-                return "pr-" + context.issue.number;
+        uses: actions/github-script@v6
+        id: compute-tag
+        with:
+          result-encoding: string
+          script: |
+            if (context.eventName === "pull_request") {
+              return "pr-" + context.issue.number;
+            }
+            if (context.eventName === "push") {
+              if (context.ref.startsWith("refs/tags/")) {
+                return context.ref.slice(10);
               }
-              if (context.eventName === "push") {
-                if (context.ref.startsWith("refs/tags/")) {
-                  return context.ref.slice(10);
-                }
-                if (context.ref === "refs/heads/develop") {
-                  return "latest";
-                }
+              if (context.ref === "refs/heads/develop") {
+                return "latest";
               }
-              return "FALSE";
+            }
+            return "FALSE";
 
       - uses: actions/checkout@v2
         name: Docker Login

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -69,11 +69,11 @@ jobs:
         name: Build Image and Push to GitHub Container Registry and DockerHub
         env:
           TAG: ${{ steps.compute-tag.outputs.result }}
-        run: |
-          docker buildx build -t ls1tum/artemis-maven-template:$TAG --push \
-            --tag ls1tum/artemis-maven-template:$TAG \
-            --platform linux/amd64,linux/arm64/v8 .
-          docker images
-          docker tag ls1tum/artemis-maven-template:$TAG ghcr.io/ls1intum/artemis-maven-template:$TAG
-          docker push ghcr.io/ls1intum/artemis-maven-template:$TAG
-        if: ${{ steps.compute-tag.outputs.result != 'FALSE' }}
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          tags: |
+            ls1tum/artemis-maven-docker:$TAG
+            ghcr.io/ls1intum/artemis-maven-docker:$TAG
+          platforms: linux/amd64,linux/arm64/v8
+          push: ${{ steps.compute-tag.outputs.result != 'FALSE' }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -74,4 +74,7 @@ jobs:
             ls1tum/artemis-maven-template:${{ steps.compute-tag.outputs.result }}
             ghcr.io/ls1intum/artemis-maven-docker:${{ steps.compute-tag.outputs.result }}
           platforms: linux/amd64,linux/arm64/v8
-          push: ${{ context.ref.startsWith("refs/tags/") }}
+          push: |
+            ${{ !steps.compute-tag.outputs.result.startsWith("pr-")
+            && steps.compute-tag.outputs.result != "latest"
+            && steps.compute-tag.outputs.result != "FALSE" }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -75,6 +75,6 @@ jobs:
             ghcr.io/ls1intum/artemis-maven-docker:${{ steps.compute-tag.outputs.result }}
           platforms: linux/amd64,linux/arm64/v8
           push: |
-            ${{ steps.compute-tag.outputs.result.startsWith("pr-") != true
-            && steps.compute-tag.outputs.result != "latest"
-            && steps.compute-tag.outputs.result != "FALSE" }}
+            ${{ steps.compute-tag.outputs.result.startsWith('pr-') != true
+            && steps.compute-tag.outputs.result != 'latest'
+            && steps.compute-tag.outputs.result != 'FALSE' }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -30,6 +30,8 @@ jobs:
             return "FALSE";
 
       - uses: actions/checkout@v2
+
+      -
         name: Docker Login
         id: docker-login
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,12 @@ MAINTAINER Stephan Krusche <krusche@in.tum.de>
 
 RUN apt-get update && apt-get install -y \
     gnupg \
+    software-properties-common \
+ && add-apt-repository ppa:cwchien/gradle \
+ && apt-get update \
+ && apt-get install gradle=7.3* -y --no-install-recommends \
  && rm -rf /var/lib/apt/lists/*
- 
+
 ENV M2_HOME /usr/share/maven
 
 RUN echo "$LANG -- $LANGUAGE -- $LC_ALL" \
@@ -14,7 +18,8 @@ RUN echo "$LANG -- $LANGUAGE -- $LC_ALL" \
     && git --version \
     && mvn --version \
     && java --version \
-    && javac --version
+    && javac --version \
+    && gradle --version
     
 
 ADD artemis-java-template /opt/artemis-java-template

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,6 @@ MAINTAINER Stephan Krusche <krusche@in.tum.de>
 
 RUN apt-get update && apt-get install -y \
     gnupg \
-    software-properties-common \
- && add-apt-repository ppa:cwchien/gradle \
- && apt-get update \
- && apt-get install gradle=7.3* -y --no-install-recommends \
  && rm -rf /var/lib/apt/lists/*
 
 ENV M2_HOME /usr/share/maven
@@ -18,8 +14,7 @@ RUN echo "$LANG -- $LANGUAGE -- $LC_ALL" \
     && git --version \
     && mvn --version \
     && java --version \
-    && javac --version \
-    && gradle --version
+    && javac --version
     
 
 ADD artemis-java-template /opt/artemis-java-template

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Docker Container for Docker Hub
 	mvn -version
 	
 	git --version
+
+    gradle --version
 	
 	
 ### Publish to Dockerhub
@@ -31,4 +33,3 @@ Docker Container for Docker Hub
 	
 	docker push ls1tum/artemis-maven-template:java17-3
 
-	

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Docker Container for Docker Hub
 	
 	git --version
 
-    gradle --version
+	gradle --version
 	
 	
 ### Publish to Dockerhub

--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ Docker Container for Docker Hub
 	mvn -version
 	
 	git --version
-
-	gradle --version
 	
 	
 ### Publish to Dockerhub


### PR DESCRIPTION
Initially, this PR was intended to add a Gradle installation to the docker container. Since this will not be required anymore, the scope has changed to introduce a new GitHub workflow that
- builds the docker images for both arm64 and amd64,
- pushes the images to GitHub Registry,
- and pushes the images to DockerHub.

An image is built for pushes to all branches of the repository, while the image will only be uploaded to DockerHub/GitHub Registry in case the respective commit was a push to the `main`-branch or tagged as a release ("refs/tags").