### PR TITLE
Start GitHub action deploy on tag push with non-empty string

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
       - release/*
-    tags: '[0-9]+.[0-9]+.[0-9]+'
+    tags: '*'
   release:
     types:
       - created


### PR DESCRIPTION
Tags for the artemis-maven-docker follow a different format than the implemented one.