### PR TITLE
Add more cached dependencies

### DIFF
--- a/artemis-java-template/pom.xml
+++ b/artemis-java-template/pom.xml
@@ -404,7 +404,7 @@
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>9.2.1</version>
+                        <version>10.1</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/artemis-java-template/pom.xml
+++ b/artemis-java-template/pom.xml
@@ -48,8 +48,8 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20211205</version>
-        </dependency>       
+            <version>20220320</version>
+        </dependency>
         <dependency>
             <groupId>me.xdrop</groupId>
             <artifactId>fuzzywuzzy</artifactId>
@@ -64,7 +64,7 @@
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-fxml</artifactId>
             <version>${javafx.version}</version>
-        </dependency>        
+        </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-media</artifactId>
@@ -119,7 +119,7 @@
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
             <version>4.3</version>
-        </dependency>       
+        </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
@@ -134,7 +134,7 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>3.3.3</version>
-        </dependency>        
+        </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
@@ -174,12 +174,12 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
             <version>${mockito4.version}</version>
-        </dependency>        
+        </dependency>
         <dependency>
             <groupId>org.jasypt</groupId>
             <artifactId>jasypt</artifactId>
             <version>1.9.3</version>
-        </dependency>             
+        </dependency>
         <dependency>
             <groupId>com.jgoodies</groupId>
             <artifactId>jgoodies-forms</artifactId>
@@ -194,7 +194,7 @@
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito2</artifactId>
             <version>${powermock2.version}</version>
-        </dependency> 
+        </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
@@ -230,6 +230,55 @@
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy-agent</artifactId>
             <version>1.12.7</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-interpolation</artifactId>
+            <version>1.12</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-interpolation</artifactId>
+            <version>1.13</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-components</artifactId>
+            <version>1.1.14</version>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-components</artifactId>
+            <version>1.1.15</version>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>org.sonatype.plexus</groupId>
+            <artifactId>plexus-build-api</artifactId>
+            <version>0.0.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <version>2.0.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.sonatype.spice</groupId>
+            <artifactId>spice-parent</artifactId>
+            <version>10</version>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>org.sonatype.forge</groupId>
+            <artifactId>forge-parent</artifactId>
+            <version>3</version>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>classworlds</groupId>
+            <artifactId>classworlds</artifactId>
+            <version>1.1</version>
         </dependency>
     </dependencies>
     <build>
@@ -275,7 +324,7 @@
                         <artifactId>tycho-compiler-jdt</artifactId>
                         <version>2.5.0</version>
                     </dependency>
-                </dependencies>                  
+                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -292,7 +341,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>2.6</version>
                 <executions>
                     <execution>
                         <id>copy-resources</id>
@@ -303,7 +352,7 @@
                         <configuration>
                             <outputDirectory>${basedir}/target</outputDirectory>
                             <resources>
-                                <resource>  
+                                <resource>
                                     <directory>resources</directory>
                                     <filtering>true</filtering>
                                 </resource>
@@ -326,7 +375,7 @@
                         <descriptorRef>jar-with-dependencies</descriptorRef>
                     </descriptorRefs>
                 </configuration>
-            </plugin>            
+            </plugin>
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>

--- a/artemis-java-template/pom.xml
+++ b/artemis-java-template/pom.xml
@@ -238,19 +238,8 @@
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-interpolation</artifactId>
-            <version>1.13</version>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-components</artifactId>
             <version>1.1.14</version>
-            <type>pom</type>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-components</artifactId>
-            <version>1.1.15</version>
             <type>pom</type>
         </dependency>
         <dependency>
@@ -279,6 +268,11 @@
             <groupId>classworlds</groupId>
             <artifactId>classworlds</artifactId>
             <version>1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+            <version>2.6</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
### Description
When running the default Maven template exercise with Static Code Analysis, the following dependencies are downloaded:
- maven-resources-plugin: 2.6 (from 3.2.0 which was actually not used)
- json-20220320
- maven-filtering: 1.1
- plexus: 2.0.3
- plexus-interpolation: 1.12
- plexus-components: 1.1.14
- plexus-build-api: 0.0.4
- plexus-utils: 2.0.5
- spice-parent: 10
- forge-parent: 3
- classworlds: 1.1

This PR adds these dependencies to the pom.xml in order to be cached and not have to be downloaded when building the classic exercise Maven-project.

### Testing Steps
1. Open a build plan in Bamboo for an exercise that executes tests and static code analysis on a Maven project. You can use [this](https://bamboo.ase.in.tum.de/build/admin/edit/editBuildDocker.action?buildKey=ATESTTESTMAVENDEPENDENCYCACHING-SOLUTION-JOB1&saved=true) build plan.
2. Verify that the selected docker images is `ls1tum/artemis-maven-template:java17-5`.
3. Start the build plan. After it has finished, open the build log.
4. Verify that the above dependencies are downloaded.
5. Change the docker image to `oleve312/artemis-maven-template:latest`. This is the image at the current state of this PR.
6. Rerun the build plan and verify that no dependencies are downloaded anymore.