### PR TITLE
Use Ubuntu 20.04 Focal as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM maven:3-eclipse-temurin-17
+# Explicitly use the image that is based on Ubuntu 20.04 Focal instead of 22.04,
+# as the newer Ubuntu release includes an updated glibc that does not work with
+# older Docker hosts.
+# c.f. https://github.com/adoptium/containers/issues/215#issuecomment-1142046045
+FROM maven:3-eclipse-temurin-17-focal
 
 MAINTAINER Stephan Krusche <krusche@in.tum.de>
 


### PR DESCRIPTION
The newer Ubuntu 22.04 includes a newer glibc that does not work with older Docker hosts [1]. For now, the JDK version is the same in both images, just the Ubuntu version is different.

[1] https://github.com/adoptium/containers/issues/215#issuecomment-1142046045